### PR TITLE
docs: update README and add setup manual for Angular ZyBot widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To embed ZyBot in any host application (HTML page, React, Angular, etc.):
 
 ## Usage
 - Access the chatbot via the Angular frontend (standalone mode) or embed the web component in any host application.
-- Backend runs on a secure Flask server and serves the widget's build files.
+- Backend runs on a secure FastAPI and serves the widget's build files.
 - Customize the chat widget and backend logic as needed.
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,17 @@ frontend/
 		public/           # Public assets
 		examples/         # Usage examples
 scripts/
-	inject.js           # Utility scripts
+    - Secure server with SSL certificates
+    - Context management and ingestion
+    - Vector store for efficient retrieval
+    - Modular chatbot logic
+- **Frontend (Angular):**
+    - Customizable chat widget
+    - Modern UI/UX
+    - Service-based architecture
+    - Can run standalone or as a web component
+
+## Project Structure
 ```
 
 ## Setup Instructions

--- a/README.md
+++ b/README.md
@@ -1,2 +1,109 @@
-# Zybot
-Zynergy Bot App
+# ZyBot
+
+
+ZyBot is a full-stack chatbot application featuring a Python backend and an Angular frontend. The Angular ZyBot widget can run as a standalone app or be built as a web component to embed in any host application. The backend serves static files and provides secure, context-aware chat services.
+
+## Features
+- **Backend (Python, Flask):**
+	- Secure server with SSL certificates
+	- Context management and ingestion
+	- Vector store for efficient retrieval
+	- Modular chatbot logic
+- **Frontend (Angular):**
+	- Customizable chat widget
+	- Modern UI/UX
+	- Service-based architecture
+	- Can run standalone or as a web component
+
+## Project Structure
+```
+backend/
+	app.py              # Main backend server
+	chatbot.py          # Chatbot logic
+	dom_context.py      # Context management
+	ingest.py           # Data ingestion
+	requirements.txt    # Python dependencies
+	run_secure.py       # Secure server runner
+	runtime_tracer.py   # Tracing and debugging
+	certs/              # SSL certificates
+	static/             # Frontend static files
+	vectorstore/        # Vector database files
+frontend/
+	package.json        # Frontend dependencies
+	chatbot-widget/     # Angular chat widget
+		src/              # Source code
+		public/           # Public assets
+		examples/         # Usage examples
+scripts/
+	inject.js           # Utility scripts
+```
+
+## Setup Instructions
+
+### Backend
+1. Navigate to `backend/`.
+2. Create and activate a Python virtual environment:
+	 ```powershell
+	 python -m venv venv
+	 .\venv\Scripts\Activate.ps1
+	 ```
+3. Install dependencies:
+	 ```powershell
+	 pip install -r requirements.txt
+	 ```
+4. Run the server (secure):
+	 ```powershell
+	 python run_secure.py
+	 ```
+
+
+### Frontend: Run Standalone
+1. Navigate to `frontend/chatbot-widget/`.
+2. Install dependencies:
+	```powershell
+	npm install
+	```
+3. Run the development server:
+	```powershell
+	ng serve
+	```
+4. Access the app at `http://localhost:4200` in your browser.
+
+### Frontend: Build as Web Component
+1. Navigate to `frontend/chatbot-widget/`.
+2. Build the project for production:
+	```powershell
+	ng build --configuration production
+	```
+3. The build output will be in `dist/chatbot-widget/browser/`.
+4. Copy the generated `main.js` (and any required files) from `dist/chatbot-widget/browser/` to your backend's `static/` folder.
+
+### Using ZyBot as a Web Component Plugin
+To embed ZyBot in any host application (HTML page, React, Angular, etc.):
+
+1. Ensure your backend is running and serving static files (e.g., `main.js`) at a public URL.
+2. Add the following code to your host application's HTML:
+	```html
+	<script src="https://localhost:9443/static/main.js"></script>
+	<zy-bot></zy-bot>
+	```
+	- Replace the `src` URL with your backend's actual static file URL if different.
+	- `<zy-bot></zy-bot>` is the custom element for the chatbot widget.
+
+
+## Usage
+- Access the chatbot via the Angular frontend (standalone mode) or embed the web component in any host application.
+- Backend runs on a secure Flask server and serves the widget's build files.
+- Customize the chat widget and backend logic as needed.
+
+
+## Contributing
+Pull requests and issues are welcome! Please follow standard coding and documentation practices.
+
+
+## License
+This project is licensed under the MIT License.
+
+---
+
+For Angular widget setup details, see `frontend/chatbot-widget/setup_manual.txt`.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To embed ZyBot in any host application (HTML page, React, Angular, etc.):
 1. Ensure your backend is running and serving static files (e.g., `main.js`) at a public URL.
 2. Add the following code to your host application's HTML:
 	```html
-	<script src="https://localhost:9443/static/main.js"></script>
+	<script src="https://your-domain.com/static/main.js"></script>
 	<zy-bot></zy-bot>
 	```
 	- Replace the `src` URL with your backend's actual static file URL if different.

--- a/frontend/chatbot-widget/setup_manual.txt
+++ b/frontend/chatbot-widget/setup_manual.txt
@@ -87,7 +87,13 @@ To embed ZyBot in any host application (HTML page, React, Angular, etc.):
     <script src="https://localhost:9443/static/main.js"></script>
     <zy-bot></zy-bot>
     ```
-    - Replace the `src` URL with your backend's actual static file URL if different.
+    <!-- For local development, use: -->
+    <script src="https://localhost:9443/static/main.js"></script>
+    <!-- For production, use your actual domain: -->
+    <script src="https://your-domain.com/static/main.js"></script>
+    <zy-bot></zy-bot>
+    ```
+    - Replace `your-domain.com` with your backend's actual static file domain in production.
     - `<zy-bot></zy-bot>` is the custom element for the chatbot widget.
 
 ---

--- a/frontend/chatbot-widget/setup_manual.txt
+++ b/frontend/chatbot-widget/setup_manual.txt
@@ -1,0 +1,77 @@
+# Angular ZyBot Widget Setup Manual
+
+This manual describes how to set up, build, and use the Angular ZyBot widget both as a standalone application and as a web component plugin for any host application.
+
+---
+
+## 1. Running Angular ZyBot Standalone
+
+### Prerequisites
+- Node.js and npm installed
+- Angular CLI installed globally (`npm install -g @angular/cli`)
+
+### Steps
+1. Navigate to the widget directory:
+   ```powershell
+   cd frontend\chatbot-widget
+   ```
+2. Install dependencies:
+   ```powershell
+   npm install
+   ```
+3. Run the development server:
+   ```powershell
+   ng serve
+   ```
+4. Access the app at `http://localhost:4200` in your browser.
+
+---
+
+## 2. Building Angular ZyBot as a Web Component
+
+### Steps
+1. Build the project for production:
+   ```powershell
+   ng build --configuration production
+   ```
+2. The build output will be in `dist/chatbot-widget/browser/`.
+3. Copy the generated `main.js` (and any required files) from `dist/chatbot-widget/browser/` to your backend's `static/` folder.
+
+---
+
+## 3. Using ZyBot as a Web Component Plugin
+
+To embed ZyBot in any host application (HTML page, React, Angular, etc.):
+
+1. Ensure your backend is running and serving static files (e.g., `main.js`) at a public URL.
+2. Add the following code to your host application's HTML:
+   ```html
+   <script src="https://localhost:9443/static/main.js"></script>
+   <zy-bot></zy-bot>
+   ```
+   - Replace the `src` URL with your backend's actual static file URL if different.
+   - `<zy-bot></zy-bot>` is the custom element for the chatbot widget.
+
+---
+
+## 4. Backend Integration
+- The Angular widget communicates with the backend via API calls.
+- Ensure the backend is running and accessible at the expected URL.
+- Update environment variables or configuration in the widget if the backend URL changes.
+
+---
+
+## 5. Troubleshooting
+- If the widget does not load, check the browser console for errors.
+- Ensure the backend is running and CORS is configured if accessing from a different domain.
+- Make sure `main.js` is correctly served from the backend's `static/` folder.
+
+---
+
+## 6. Customization
+- You can style or extend the widget by modifying the Angular source code in `src/app/chat-widget/`.
+- Rebuild and redeploy the widget after making changes.
+
+---
+
+For more details, refer to the main project README.

--- a/frontend/chatbot-widget/setup_manual.txt
+++ b/frontend/chatbot-widget/setup_manual.txt
@@ -84,7 +84,7 @@ To embed ZyBot in any host application (HTML page, React, Angular, etc.):
 1. Ensure your backend is running and serving static files (e.g., `main.js`) at a public URL.
 2. Add the following code to your host application's HTML:
     ```html
-    <script src="https://localhost:9443/static/main.js"></script>
+    <script src="http://ec2-13-200-117-156.ap-south-1.compute.amazonaws.com:8000/chat'"></script>
     <zy-bot></zy-bot>
     ```
     - Replace the `src` URL with your backend's actual static file URL if different.

--- a/frontend/chatbot-widget/setup_manual.txt
+++ b/frontend/chatbot-widget/setup_manual.txt
@@ -1,10 +1,13 @@
+
 # Angular ZyBot Widget Setup Manual
 
 This manual describes how to set up, build, and use the Angular ZyBot widget both as a standalone application and as a web component plugin for any host application.
 
 ---
 
-## 1. Running Angular ZyBot Standalone
+## 1. Running Angular ZyBot Standalone (Full Angular App)
+
+You can run the Angular ZyBot as a full application for development or testing. Follow these steps:
 
 ### Prerequisites
 - Node.js and npm installed
@@ -12,28 +15,63 @@ This manual describes how to set up, build, and use the Angular ZyBot widget bot
 
 ### Steps
 1. Navigate to the widget directory:
-   ```powershell
-   cd frontend\chatbot-widget
-   ```
+    ```powershell
+    cd frontend\chatbot-widget
+    ```
 2. Install dependencies:
-   ```powershell
-   npm install
-   ```
-3. Run the development server:
-   ```powershell
-   ng serve
-   ```
-4. Access the app at `http://localhost:4200` in your browser.
+    ```powershell
+    npm install
+    ```
+3. Make sure the following files are set up for standalone mode:
+    - **`src/index.html`**
+       ```html
+       <!-- NOTE: This file is for running the Angular app independently. Use <app-root> for standalone mode. -->
+       <body>
+          <app-root></app-root>
+       </body>
+       ```
+    - **`src/main.ts`**
+       ```typescript
+       // NOTE: This entry point is for standalone Angular app. Use this for development and testing.
+       import { bootstrapApplication } from '@angular/platform-browser';
+       import { App } from './app/app';
+       import { appConfig } from './app/app.config';
+
+       bootstrapApplication(App, appConfig);
+       ```
+    - **`src/app/app.ts`**
+       ```typescript
+       // NOTE: This is the root Angular component for standalone mode.
+       import { Component, signal } from '@angular/core';
+       import { ChatWidgetComponent } from './chat-widget/chat-widget.component';
+
+       @Component({
+          selector: 'app-root',
+          standalone: true,
+          imports: [ChatWidgetComponent],
+          template: `<app-chat-widget></app-chat-widget>`
+       })
+       export class App {
+          protected readonly title = signal('chatbot-widget');
+       }
+       ```
+4. Run the development server:
+    ```powershell
+    ng serve
+    ```
+5. Access the app at `http://localhost:4200` in your browser.
 
 ---
 
 ## 2. Building Angular ZyBot as a Web Component
 
+You can build the widget as a web component to embed in any host application.
+
 ### Steps
 1. Build the project for production:
-   ```powershell
-   ng build --configuration production
-   ```
+    ```powershell
+    ng build --configuration production
+    ```
 2. The build output will be in `dist/chatbot-widget/browser/`.
 3. Copy the generated `main.js` (and any required files) from `dist/chatbot-widget/browser/` to your backend's `static/` folder.
 
@@ -45,12 +83,12 @@ To embed ZyBot in any host application (HTML page, React, Angular, etc.):
 
 1. Ensure your backend is running and serving static files (e.g., `main.js`) at a public URL.
 2. Add the following code to your host application's HTML:
-   ```html
-   <script src="https://localhost:9443/static/main.js"></script>
-   <zy-bot></zy-bot>
-   ```
-   - Replace the `src` URL with your backend's actual static file URL if different.
-   - `<zy-bot></zy-bot>` is the custom element for the chatbot widget.
+    ```html
+    <script src="https://localhost:9443/static/main.js"></script>
+    <zy-bot></zy-bot>
+    ```
+    - Replace the `src` URL with your backend's actual static file URL if different.
+    - `<zy-bot></zy-bot>` is the custom element for the chatbot widget.
 
 ---
 

--- a/frontend/chatbot-widget/src/app/chat-widget/chat-widget.component.ts
+++ b/frontend/chatbot-widget/src/app/chat-widget/chat-widget.component.ts
@@ -77,7 +77,7 @@ export class ChatWidgetComponent implements AfterViewChecked, OnInit {
   }
   
   private showWelcomeMessage() {
-    const welcomeMessage = "👋 Welcome to ZyBot! I'm your virtual assistant ready to help with your questions. Feel free to ask me anything about this website.";
+    const welcomeMessage = "👋 Welcome to ZyBot! I'm your virtual buddy ready to help with your questions. Feel free to ask me anything about this application.";
     
     this.messages.push({
       text: welcomeMessage,


### PR DESCRIPTION
This pull request significantly improves documentation for the ZyBot project by providing a comprehensive overview in the main `README.md` and adding a dedicated setup manual for the Angular ZyBot widget. The changes clarify the project's structure, setup instructions, usage modes, and integration steps, making it much easier for new developers and users to get started and understand how to deploy ZyBot as both a standalone app and an embeddable web component.

**Documentation improvements:**

* Expanded and clarified the main `README.md` to include detailed project features, structure, setup instructions for both backend and frontend, usage guidelines, and licensing information.
* Added `frontend/chatbot-widget/setup_manual.txt`, a step-by-step guide for building, running, and embedding the Angular ZyBot widget, including troubleshooting and customization tips.