### PR TITLE
fix: update CORS settings to allow all origins and change chat URL to production endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -19,7 +19,7 @@ chat_chain = load_chain()  # default is "developer"
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5199", "http://localhost:4200"], 
+    allow_origins=["http://localhost:5199", "http://localhost:4200", "*"], 
     allow_methods=["*"], 
     allow_headers=["*"],
     allow_credentials=True

--- a/frontend/chatbot-widget/src/environments/environment.prod.ts
+++ b/frontend/chatbot-widget/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  chatUrl: 'https://your-production-chat-url.com/chat'
+  chatUrl: 'http://ec2-13-200-117-156.ap-south-1.compute.amazonaws.com:8000/chat'
 };

--- a/frontend/chatbot-widget/src/environments/environment.ts
+++ b/frontend/chatbot-widget/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  chatUrl: 'https://127.0.0.1:9443/chat'
+  chatUrl: 'http://ec2-13-200-117-156.ap-south-1.compute.amazonaws.com:8000/chat'
 };

--- a/frontend/chatbot-widget/src/environments/environment.ts
+++ b/frontend/chatbot-widget/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  chatUrl: 'http://ec2-13-200-117-156.ap-south-1.compute.amazonaws.com:8000/chat'
+  chatUrl: 'https://ec2-13-200-117-156.ap-south-1.compute.amazonaws.com:8000/chat'
 };


### PR DESCRIPTION
This pull request updates the backend and frontend configuration to enable broader access and connect the chatbot widget to a new server endpoint. The most important changes are grouped below.

Backend configuration:

* Expanded CORS policy in `backend/app.py` to allow requests from any origin by adding `"*"` to the `allow_origins` list.

Frontend environment updates:

* Updated the `chatUrl` in both `environment.ts` and `environment.prod.ts` to point to `http://ec2-13-200-117-156.ap-south-1.compute.amazonaws.com:8000/chat` instead of the previous local or placeholder URLs, ensuring both development and production environments use the new server endpoint. [[1]](diffhunk://#diff-aca173309a7819642e25415eaf6762fefacac324c4e137789cba4d06d366f17fL3-R3) [[2]](diffhunk://#diff-5a624190f62823b4cb1195208dadbc2d5d6391bd4a6834305f1f9b8a14d1bbb3L3-R3)